### PR TITLE
Fix the white screen on launch; Add loading screen

### DIFF
--- a/code/assets.lua
+++ b/code/assets.lua
@@ -188,10 +188,8 @@ function LoadAssets()
     local soundEffectLambdas = LoadSFX(settings.sfx_directory)
     LoadFonts()
 
-    for i, soundEffectLambda in ipairs(soundEffectLambdas) do
-        soundEffectLambda()
-    end
-
     FinishLoadingMusic()
     FinishLoadingSFX()
+
+    return soundEffectLambdas
 end

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -37,7 +37,9 @@ local function LoadMusic(directoryName)
             Music[a] = love.audio.newSource(directoryName .. i, "static")
         end
     end
+end
 
+local function FinishLoadingMusic()
     for i, v in pairs(Music) do
         v:setLooping(true)
         v:setVolume(MusicVolume / 100)
@@ -177,4 +179,6 @@ function LoadAssets()
     LoadShouts(settings.shouts_directory)
     LoadSFX(settings.sfx_directory)
     LoadMisc()
+
+    FinishLoadingMusic()
 end

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -3,7 +3,7 @@ function LoadBackgrounds(directoryName)
         NONE = {}
     }
 
-    files = love.filesystem.getDirectoryItems(directoryName)
+    local files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
         if string.match(i, ".png") then
@@ -26,7 +26,7 @@ end
 function LoadMusic(directoryName)
     Music = {}
 
-    files = love.filesystem.getDirectoryItems(directoryName)
+    local files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
         if string.match(i, ".mp3") then
@@ -47,7 +47,7 @@ end
 function LoadSprites(directoryName)
     Sprites = {}
 
-    files = love.filesystem.getDirectoryItems(directoryName)
+    local files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
         if string.match(i, ".png") then
@@ -96,7 +96,7 @@ end
 function LoadShouts(directoryName)
     Shouts = {}
 
-    files = love.filesystem.getDirectoryItems(directoryName)
+    local files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
         if string.match(i, ".png") then
@@ -109,7 +109,7 @@ end
 function LoadSFX(directoryName)
     Sounds = {}
 
-    files = love.filesystem.getDirectoryItems(directoryName)
+    local files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
         if string.match(i, ".mp3") then

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -4,23 +4,29 @@ local function LoadBackgrounds(directoryName)
     }
 
     local files = love.filesystem.getDirectoryItems(directoryName)
+    local lambdas = {}
 
-    for b, i in ipairs(files) do
-        if string.match(i, ".png") then
-            if string.match(i, "_1") then
-                local a = i:gsub(".png", "")
-                local a = a:gsub("_1", "")
-                Backgrounds[a] = {love.graphics.newImage(directoryName .. i)}
-            elseif string.match(i, "_2") then
-                local a = i:gsub(".png", "")
-                local a = a:gsub("_2", "")
-                table.insert(Backgrounds[a], love.graphics.newImage(directoryName .. i))
-            else
-                local a = i:gsub(".png", "")
-                Backgrounds[a] = {love.graphics.newImage(directoryName .. i)}
+    for index, background in ipairs(files) do
+        lambdas[index] = function()
+            print("loading background", background)
+            if string.match(background, ".png") then
+                if string.match(background, "_1") then
+                    local a = background:gsub(".png", "")
+                    local a = a:gsub("_1", "")
+                    Backgrounds[a] = {love.graphics.newImage(directoryName .. background)}
+                elseif string.match(background, "_2") then
+                    local a = background:gsub(".png", "")
+                    local a = a:gsub("_2", "")
+                    table.insert(Backgrounds[a], love.graphics.newImage(directoryName .. background))
+                else
+                    local a = background:gsub(".png", "")
+                    Backgrounds[a] = {love.graphics.newImage(directoryName .. background)}
+                end
             end
         end
     end
+
+    return lambdas
 end
 
 local function LoadMusic(directoryName)
@@ -56,62 +62,74 @@ local function LoadSprites(directoryName)
     Sprites = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
+    local lambdas = {}
 
-    for b, i in ipairs(files) do
-        if string.match(i, ".png") then
-            if string.match(i, "_") then
-                if string.match(i, "_1") then
-                    local a = i:gsub(".png", "")
-                    local a = a:gsub("_1", "")
-                    local a = a .. "Animation"
-                    Sprites[a] = {love.graphics.newImage(directoryName .. i)}
-                elseif string.match(i, "_2") then
-                    local a = i:gsub(".png", "")
-                    local a = a:gsub("_2", "")
-                    local a = a .. "Animation"
-                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
-                elseif string.match(i, "_3") then
-                    local a = i:gsub(".png", "")
-                    local a = a:gsub("_3", "")
-                    local a = a .. "Animation"
-                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
-                elseif string.match(i, "_4") then
-                    local a = i:gsub(".png", "")
-                    local a = a:gsub("_4", "")
-                    local a = a .. "Animation"
-                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
-                elseif string.match(i, "_5") then
-                    local a = i:gsub(".png", "")
-                    local a = a:gsub("_5", "")
-                    local a = a .. "Animation"
-                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
-                elseif string.match(i, "_6") then
-                    local a = i:gsub(".png", "")
-                    local a = a:gsub("_6", "")
-                    local a = a .. "Animation"
-                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
+    for index, sprite in ipairs(files) do
+        lambdas[index] = function()
+            print("loading sprite", sprite)
+            if string.match(sprite, ".png") then
+                if string.match(sprite, "_") then
+                    if string.match(sprite, "_1") then
+                        local a = sprite:gsub(".png", "")
+                        local a = a:gsub("_1", "")
+                        local a = a .. "Animation"
+                        Sprites[a] = {love.graphics.newImage(directoryName .. sprite)}
+                    elseif string.match(sprite, "_2") then
+                        local a = sprite:gsub(".png", "")
+                        local a = a:gsub("_2", "")
+                        local a = a .. "Animation"
+                        table.insert(Sprites[a], love.graphics.newImage(directoryName .. sprite))
+                    elseif string.match(sprite, "_3") then
+                        local a = sprite:gsub(".png", "")
+                        local a = a:gsub("_3", "")
+                        local a = a .. "Animation"
+                        table.insert(Sprites[a], love.graphics.newImage(directoryName .. sprite))
+                    elseif string.match(sprite, "_4") then
+                        local a = sprite:gsub(".png", "")
+                        local a = a:gsub("_4", "")
+                        local a = a .. "Animation"
+                        table.insert(Sprites[a], love.graphics.newImage(directoryName .. sprite))
+                    elseif string.match(sprite, "_5") then
+                        local a = sprite:gsub(".png", "")
+                        local a = a:gsub("_5", "")
+                        local a = a .. "Animation"
+                        table.insert(Sprites[a], love.graphics.newImage(directoryName .. sprite))
+                    elseif string.match(sprite, "_6") then
+                        local a = sprite:gsub(".png", "")
+                        local a = a:gsub("_6", "")
+                        local a = a .. "Animation"
+                        table.insert(Sprites[a], love.graphics.newImage(directoryName .. sprite))
+                    end
+                elseif string.match(sprite, "Font") then
+                    False = false
+                else
+                    local a = sprite:gsub(".png", "")
+                    Sprites[a] = love.graphics.newImage(directoryName .. sprite)
                 end
-            elseif string.match(i, "Font") then
-                False = false
-            else
-                local a = i:gsub(".png", "")
-                Sprites[a] = love.graphics.newImage(directoryName .. i)
             end
         end
     end
+
+    return lambdas
 end
 
 local function LoadShouts(directoryName)
     Shouts = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
+    local lambdas = {}
 
-    for b, i in ipairs(files) do
-        if string.match(i, ".png") then
-            local a = i:gsub(".png", "")
-            Shouts[a] = love.graphics.newImage(directoryName .. i)
+    for index, shout in ipairs(files) do
+        lambdas[index] = function()
+            print("loading shout", sprite)
+            if string.match(shout, ".png") then
+                local a = shout:gsub(".png", "")
+                Shouts[a] = love.graphics.newImage(directoryName .. shout)
+            end
         end
     end
+
+    return lambdas
 end
 
 local function LoadSFX(directoryName)
@@ -188,24 +206,23 @@ local function LoadFonts()
 end
 
 function LoadAssets()
-    LoadBackgrounds(settings.background_directory)
-    local musicLambdas = LoadMusic(settings.music_directory)
-    LoadSprites(settings.sprite_directory)
-    LoadShouts(settings.shouts_directory)
-    local soundEffectLambdas = LoadSFX(settings.sfx_directory)
+    local allLambdas = {}
+    local i = 1
+    local function appendListToList(subList)
+        for _, lambda in ipairs(subList) do
+            allLambdas[i] = lambda
+            i = i + 1
+        end
+    end
+
+    -- Loading fonts is pretty quick compared to everything else
     LoadFonts()
 
-    local allLambdas = {}
-    local index = 1
-    for i, lambda in ipairs(soundEffectLambdas) do
-        allLambdas[index] = lambda
-        index = index + 1
-    end
-
-    for i, lambda in ipairs(musicLambdas) do
-        allLambdas[index] = lambda
-        index = index + 1
-    end
+    appendListToList(LoadBackgrounds(settings.background_directory))
+    appendListToList(LoadMusic(settings.music_directory))
+    appendListToList(LoadSprites(settings.sprite_directory))
+    appendListToList(LoadShouts(settings.shouts_directory))
+    appendListToList(LoadSFX(settings.sfx_directory))
 
     return allLambdas
 end

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -1,23 +1,23 @@
 function LoadBackgrounds(directoryName)
     Backgrounds = {
-        NONE = {},
+        NONE = {}
     }
 
     files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
-        if string.match(i,".png") then
-            if string.match(i,"_1") then
-                local a = i:gsub(".png","")
-                local a = a:gsub("_1","")
-                Backgrounds[a] = {love.graphics.newImage(directoryName..i)}
-            elseif string.match(i,"_2") then
-                local a = i:gsub(".png","")
-                local a = a:gsub("_2","")
-                table.insert(Backgrounds[a], love.graphics.newImage(directoryName..i))
+        if string.match(i, ".png") then
+            if string.match(i, "_1") then
+                local a = i:gsub(".png", "")
+                local a = a:gsub("_1", "")
+                Backgrounds[a] = {love.graphics.newImage(directoryName .. i)}
+            elseif string.match(i, "_2") then
+                local a = i:gsub(".png", "")
+                local a = a:gsub("_2", "")
+                table.insert(Backgrounds[a], love.graphics.newImage(directoryName .. i))
             else
-                local a = i:gsub(".png","")
-                Backgrounds[a] = {love.graphics.newImage(directoryName..i)}
+                local a = i:gsub(".png", "")
+                Backgrounds[a] = {love.graphics.newImage(directoryName .. i)}
             end
         end
     end
@@ -29,16 +29,16 @@ function LoadMusic(directoryName)
     files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
-        if string.match(i,".mp3") then
-            local a = i:gsub(".mp3",""):upper()
-            Music[a] = love.audio.newSource(directoryName..i, "static")
-        elseif string.match(i,".wav") then
-            local a = i:gsub(".wav",""):upper()
-            Music[a] = love.audio.newSource(directoryName..i, "static")
+        if string.match(i, ".mp3") then
+            local a = i:gsub(".mp3", ""):upper()
+            Music[a] = love.audio.newSource(directoryName .. i, "static")
+        elseif string.match(i, ".wav") then
+            local a = i:gsub(".wav", ""):upper()
+            Music[a] = love.audio.newSource(directoryName .. i, "static")
         end
     end
 
-    for i,v in pairs(Music) do
+    for i, v in pairs(Music) do
         v:setLooping(true)
         v:setVolume(MusicVolume / 100)
     end
@@ -50,44 +50,44 @@ function LoadSprites(directoryName)
     files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
-        if string.match(i,".png") then
-            if string.match(i,"_") then
-                if string.match(i,"_1") then
-                    local a = i:gsub(".png","")
-                    local a = a:gsub("_1","")
-                    local a = a.."Animation"
-                    Sprites[a] = {love.graphics.newImage(directoryName..i)}
-                elseif string.match(i,"_2") then
-                    local a = i:gsub(".png","")
-                    local a = a:gsub("_2","")
-                    local a = a.."Animation"
-                    table.insert(Sprites[a],love.graphics.newImage(directoryName..i))
-                elseif string.match(i,"_3") then
-                    local a = i:gsub(".png","")
-                    local a = a:gsub("_3","")
-                    local a = a.."Animation"
-                    table.insert(Sprites[a],love.graphics.newImage(directoryName..i))
-                elseif string.match(i,"_4") then
-                    local a = i:gsub(".png","")
-                    local a = a:gsub("_4","")
-                    local a = a.."Animation"
-                    table.insert(Sprites[a],love.graphics.newImage(directoryName..i))
-                elseif string.match(i,"_5") then
-                    local a = i:gsub(".png","")
-                    local a = a:gsub("_5","")
-                    local a = a.."Animation"
-                    table.insert(Sprites[a],love.graphics.newImage(directoryName..i))
-                elseif string.match(i,"_6") then
-                    local a = i:gsub(".png","")
-                    local a = a:gsub("_6","")
-                    local a = a.."Animation"
-                    table.insert(Sprites[a],love.graphics.newImage(directoryName..i))
+        if string.match(i, ".png") then
+            if string.match(i, "_") then
+                if string.match(i, "_1") then
+                    local a = i:gsub(".png", "")
+                    local a = a:gsub("_1", "")
+                    local a = a .. "Animation"
+                    Sprites[a] = {love.graphics.newImage(directoryName .. i)}
+                elseif string.match(i, "_2") then
+                    local a = i:gsub(".png", "")
+                    local a = a:gsub("_2", "")
+                    local a = a .. "Animation"
+                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
+                elseif string.match(i, "_3") then
+                    local a = i:gsub(".png", "")
+                    local a = a:gsub("_3", "")
+                    local a = a .. "Animation"
+                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
+                elseif string.match(i, "_4") then
+                    local a = i:gsub(".png", "")
+                    local a = a:gsub("_4", "")
+                    local a = a .. "Animation"
+                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
+                elseif string.match(i, "_5") then
+                    local a = i:gsub(".png", "")
+                    local a = a:gsub("_5", "")
+                    local a = a .. "Animation"
+                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
+                elseif string.match(i, "_6") then
+                    local a = i:gsub(".png", "")
+                    local a = a:gsub("_6", "")
+                    local a = a .. "Animation"
+                    table.insert(Sprites[a], love.graphics.newImage(directoryName .. i))
                 end
-            elseif string.match(i,"Font") then
+            elseif string.match(i, "Font") then
                 False = false
             else
-                local a = i:gsub(".png","")
-                Sprites[a] = love.graphics.newImage(directoryName..i)
+                local a = i:gsub(".png", "")
+                Sprites[a] = love.graphics.newImage(directoryName .. i)
             end
         end
     end
@@ -99,9 +99,9 @@ function LoadShouts(directoryName)
     files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
-        if string.match(i,".png") then
-            local a = i:gsub(".png","")
-            Shouts[a] = love.graphics.newImage(directoryName..i)
+        if string.match(i, ".png") then
+            local a = i:gsub(".png", "")
+            Shouts[a] = love.graphics.newImage(directoryName .. i)
         end
     end
 end
@@ -112,16 +112,16 @@ function LoadSFX(directoryName)
     files = love.filesystem.getDirectoryItems(directoryName)
 
     for b, i in ipairs(files) do
-        if string.match(i,".mp3") then
-            local a = i:gsub(".mp3",""):upper()
-            Sounds[a] = love.audio.newSource(directoryName..i, "static")
-        elseif string.match(i,".wav") then
-            local a = i:gsub(".wav",""):upper()
-            Sounds[a] = love.audio.newSource(directoryName..i, "static")
+        if string.match(i, ".mp3") then
+            local a = i:gsub(".mp3", ""):upper()
+            Sounds[a] = love.audio.newSource(directoryName .. i, "static")
+        elseif string.match(i, ".wav") then
+            local a = i:gsub(".wav", ""):upper()
+            Sounds[a] = love.audio.newSource(directoryName .. i, "static")
         end
     end
 
-    for i,v in pairs(Sounds) do
+    for i, v in pairs(Sounds) do
         if i ~= "maletalk" and i ~= "femaletalk" then
             v:setVolume(SFXVolume / 100 / 2)
         else
@@ -131,12 +131,42 @@ function LoadSFX(directoryName)
 end
 
 function LoadMisc()
-    GameFont = love.graphics.newImageFont("sprites/GameFont.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():,-'*" .. '`"', 2)
-    SmallFont = love.graphics.newImageFont("sprites/SmallFont.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():", 1)
-    GameFontBold = love.graphics.newImageFont("sprites/GameFontBold.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():,-'*" .. '`"', 2)
-    SmallFontBold = love.graphics.newImageFont("sprites/SmallFontBold.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():", 1)
-    CreditsFont = love.graphics.newImageFont("sprites/CreditsFont.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():,-'*" .. '`"/#@', 2)
-    CreditsSmallFont = love.graphics.newImageFont("sprites/CreditsSmallFont.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~:(),-'*" .. '"``/#@', 1)
+    GameFont =
+        love.graphics.newImageFont(
+        "sprites/GameFont.png",
+        " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():,-'*" .. '`"',
+        2
+    )
+    SmallFont =
+        love.graphics.newImageFont(
+        "sprites/SmallFont.png",
+        " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():",
+        1
+    )
+    GameFontBold =
+        love.graphics.newImageFont(
+        "sprites/GameFontBold.png",
+        " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():,-'*" .. '`"',
+        2
+    )
+    SmallFontBold =
+        love.graphics.newImageFont(
+        "sprites/SmallFontBold.png",
+        " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():",
+        1
+    )
+    CreditsFont =
+        love.graphics.newImageFont(
+        "sprites/CreditsFont.png",
+        " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~():,-'*" .. '`"/#@',
+        2
+    )
+    CreditsSmallFont =
+        love.graphics.newImageFont(
+        "sprites/CreditsSmallFont.png",
+        " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~:(),-'*" .. '"``/#@',
+        1
+    )
     love.graphics.setFont(GameFont)
 end
 

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -122,7 +122,9 @@ local function LoadSFX(directoryName)
             Sounds[a] = love.audio.newSource(directoryName .. i, "static")
         end
     end
+end
 
+local function FinishLoadingSFX()
     for i, v in pairs(Sounds) do
         if i ~= "maletalk" and i ~= "femaletalk" then
             v:setVolume(SFXVolume / 100 / 2)
@@ -181,4 +183,5 @@ function LoadAssets()
     LoadFonts()
 
     FinishLoadingMusic()
+    FinishLoadingSFX()
 end

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -1,4 +1,4 @@
-function LoadBackgrounds(directoryName)
+local function LoadBackgrounds(directoryName)
     Backgrounds = {
         NONE = {}
     }
@@ -23,7 +23,7 @@ function LoadBackgrounds(directoryName)
     end
 end
 
-function LoadMusic(directoryName)
+local function LoadMusic(directoryName)
     Music = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
@@ -44,7 +44,7 @@ function LoadMusic(directoryName)
     end
 end
 
-function LoadSprites(directoryName)
+local function LoadSprites(directoryName)
     Sprites = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
@@ -93,7 +93,7 @@ function LoadSprites(directoryName)
     end
 end
 
-function LoadShouts(directoryName)
+local function LoadShouts(directoryName)
     Shouts = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
@@ -106,7 +106,7 @@ function LoadShouts(directoryName)
     end
 end
 
-function LoadSFX(directoryName)
+local function LoadSFX(directoryName)
     Sounds = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
@@ -130,7 +130,7 @@ function LoadSFX(directoryName)
     end
 end
 
-function LoadMisc()
+local function LoadMisc()
     GameFont =
         love.graphics.newImageFont(
         "sprites/GameFont.png",

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -183,6 +183,7 @@ local function LoadFonts()
         " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?~:(),-'*" .. '"``/#@',
         1
     )
+    LoadingFont = love.graphics.newFont(24) -- it really doesn't matter what this font is
     love.graphics.setFont(GameFont)
 end
 

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -27,16 +27,22 @@ local function LoadMusic(directoryName)
     Music = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
+    local lambdas = {}
 
-    for b, i in ipairs(files) do
-        if string.match(i, ".mp3") then
-            local a = i:gsub(".mp3", ""):upper()
-            Music[a] = love.audio.newSource(directoryName .. i, "static")
-        elseif string.match(i, ".wav") then
-            local a = i:gsub(".wav", ""):upper()
-            Music[a] = love.audio.newSource(directoryName .. i, "static")
+    for index, song in ipairs(files) do
+        lambdas[index] = function()
+            print("loading music", song)
+            if string.match(song, ".mp3") then
+                local a = song:gsub(".mp3", ""):upper()
+                Music[a] = love.audio.newSource(directoryName .. song, "static")
+            elseif string.match(song, ".wav") then
+                local a = song:gsub(".wav", ""):upper()
+                Music[a] = love.audio.newSource(directoryName .. song, "static")
+            end
         end
     end
+
+    return lambdas
 end
 
 local function FinishLoadingMusic()
@@ -112,10 +118,10 @@ local function LoadSFX(directoryName)
     Sounds = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
-    local loadSFXLambdas = {}
+    local lambdas = {}
 
     for index, sfx in ipairs(files) do
-        loadSFXLambdas[index] = function()
+        lambdas[index] = function()
             print("loading SFX", sfx)
             if string.match(sfx, ".mp3") then
                 local a = sfx:gsub(".mp3", ""):upper()
@@ -127,7 +133,7 @@ local function LoadSFX(directoryName)
         end
     end
 
-    return loadSFXLambdas
+    return lambdas
 end
 
 local function FinishLoadingSFX()
@@ -182,14 +188,28 @@ end
 
 function LoadAssets()
     LoadBackgrounds(settings.background_directory)
-    LoadMusic(settings.music_directory)
+    local musicLambdas = LoadMusic(settings.music_directory)
     LoadSprites(settings.sprite_directory)
     LoadShouts(settings.shouts_directory)
     local soundEffectLambdas = LoadSFX(settings.sfx_directory)
     LoadFonts()
 
+    local allLambdas = {}
+    local index = 1
+    for i, lambda in ipairs(soundEffectLambdas) do
+        allLambdas[index] = lambda
+        index = index + 1
+    end
+
+    for i, lambda in ipairs(musicLambdas) do
+        allLambdas[index] = lambda
+        index = index + 1
+    end
+
+    return allLambdas
+end
+
+function FinishLoadingAssets()
     FinishLoadingMusic()
     FinishLoadingSFX()
-
-    return soundEffectLambdas
 end

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -112,16 +112,22 @@ local function LoadSFX(directoryName)
     Sounds = {}
 
     local files = love.filesystem.getDirectoryItems(directoryName)
+    local loadSFXLambdas = {}
 
-    for b, i in ipairs(files) do
-        if string.match(i, ".mp3") then
-            local a = i:gsub(".mp3", ""):upper()
-            Sounds[a] = love.audio.newSource(directoryName .. i, "static")
-        elseif string.match(i, ".wav") then
-            local a = i:gsub(".wav", ""):upper()
-            Sounds[a] = love.audio.newSource(directoryName .. i, "static")
+    for index, sfx in ipairs(files) do
+        loadSFXLambdas[index] = function()
+            print("loading SFX", sfx)
+            if string.match(sfx, ".mp3") then
+                local a = sfx:gsub(".mp3", ""):upper()
+                Sounds[a] = love.audio.newSource(directoryName .. sfx, "static")
+            elseif string.match(sfx, ".wav") then
+                local a = sfx:gsub(".wav", ""):upper()
+                Sounds[a] = love.audio.newSource(directoryName .. sfx, "static")
+            end
         end
     end
+
+    return loadSFXLambdas
 end
 
 local function FinishLoadingSFX()
@@ -179,8 +185,12 @@ function LoadAssets()
     LoadMusic(settings.music_directory)
     LoadSprites(settings.sprite_directory)
     LoadShouts(settings.shouts_directory)
-    LoadSFX(settings.sfx_directory)
+    local soundEffectLambdas = LoadSFX(settings.sfx_directory)
     LoadFonts()
+
+    for i, soundEffectLambda in ipairs(soundEffectLambdas) do
+        soundEffectLambda()
+    end
 
     FinishLoadingMusic()
     FinishLoadingSFX()

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -8,7 +8,6 @@ local function LoadBackgrounds(directoryName)
 
     for index, background in ipairs(files) do
         lambdas[index] = function()
-            print("loading background", background)
             if string.match(background, ".png") then
                 if string.match(background, "_1") then
                     local a = background:gsub(".png", "")
@@ -37,7 +36,6 @@ local function LoadMusic(directoryName)
 
     for index, song in ipairs(files) do
         lambdas[index] = function()
-            print("loading music", song)
             if string.match(song, ".mp3") then
                 local a = song:gsub(".mp3", ""):upper()
                 Music[a] = love.audio.newSource(directoryName .. song, "static")
@@ -66,7 +64,6 @@ local function LoadSprites(directoryName)
 
     for index, sprite in ipairs(files) do
         lambdas[index] = function()
-            print("loading sprite", sprite)
             if string.match(sprite, ".png") then
                 if string.match(sprite, "_") then
                     if string.match(sprite, "_1") then
@@ -121,7 +118,6 @@ local function LoadShouts(directoryName)
 
     for index, shout in ipairs(files) do
         lambdas[index] = function()
-            print("loading shout", sprite)
             if string.match(shout, ".png") then
                 local a = shout:gsub(".png", "")
                 Shouts[a] = love.graphics.newImage(directoryName .. shout)
@@ -140,7 +136,6 @@ local function LoadSFX(directoryName)
 
     for index, sfx in ipairs(files) do
         lambdas[index] = function()
-            print("loading SFX", sfx)
             if string.match(sfx, ".mp3") then
                 local a = sfx:gsub(".mp3", ""):upper()
                 Sounds[a] = love.audio.newSource(directoryName .. sfx, "static")

--- a/code/assets.lua
+++ b/code/assets.lua
@@ -132,7 +132,7 @@ local function LoadSFX(directoryName)
     end
 end
 
-local function LoadMisc()
+local function LoadFonts()
     GameFont =
         love.graphics.newImageFont(
         "sprites/GameFont.png",
@@ -178,7 +178,7 @@ function LoadAssets()
     LoadSprites(settings.sprite_directory)
     LoadShouts(settings.shouts_directory)
     LoadSFX(settings.sfx_directory)
-    LoadMisc()
+    LoadFonts()
 
     FinishLoadingMusic()
 end

--- a/code/screens/options.lua
+++ b/code/screens/options.lua
@@ -98,30 +98,6 @@ blip2 = love.audio.newSource("sounds/selectblip2.wav", "static")
 jingle = love.audio.newSource("sounds/selectjingle.wav", "static")
 blip2:setVolume(settings.sfx_volume / 100 / 2)
 jingle:setVolume(settings.sfx_volume / 100 / 2)
-Music = {}
-Sounds = {}
-
-musicFiles = love.filesystem.getDirectoryItems(settings.music_directory)
-soundFiles = love.filesystem.getDirectoryItems(settings.sfx_directory)
-
-for b, i in ipairs(musicFiles) do
-    if string.match(i, ".mp3") then
-        local a = i:gsub(".mp3", ""):upper()
-        Music[a] = love.audio.newSource(settings.music_directory .. i, "static")
-    elseif string.match(i, ".wav") then
-        local a = i:gsub(".wav", ""):upper()
-        Music[a] = love.audio.newSource(settings.music_directory .. i, "static")
-    end
-end
-for b, i in ipairs(soundFiles) do
-    if string.match(i, ".mp3") then
-        local a = i:gsub(".mp3", ""):upper()
-        Sounds[a] = love.audio.newSource(settings.sfx_directory .. i, "static")
-    elseif string.match(i, ".wav") then
-        local a = i:gsub(".wav", ""):upper()
-        Sounds[a] = love.audio.newSource(settings.sfx_directory .. i, "static")
-    end
-end
 
 OptionsConfig = {
     displayed = false,

--- a/code/screens/options.lua
+++ b/code/screens/options.lua
@@ -1,12 +1,10 @@
-
 local optionsSelections = {}
 
-optionsSelections[0] = "Back";
-optionsSelections[1] = "Volume";
-optionsSelections[2] = settings.displayModes[settings.displayModesIndex];
+optionsSelections[0] = "Back"
+optionsSelections[1] = "Volume"
+optionsSelections[2] = settings.displayModes[settings.displayModesIndex]
 
 function DrawOptionsScreen()
-
     love.graphics.clear(unpack(colors.black))
     GameFont:setLineHeight(1)
 
@@ -16,49 +14,56 @@ function DrawOptionsScreen()
     local blackImage = love.graphics.newImage(settings.black_screen_path)
     local blackImageScale = 3
 
-    local backW = (dimensions.window_width * 1/5)
-    local backX = (dimensions.window_width/2 - backW/2)
-    local backY = blackImage:getHeight()*blackImageScale + 10
+    local backW = (dimensions.window_width * 1 / 5)
+    local backX = (dimensions.window_width / 2 - backW / 2)
+    local backY = blackImage:getHeight() * blackImageScale + 10
     local backH = 60
 
-    local volumeW = (dimensions.window_width * 1/3.75)
-    local volumeX = (dimensions.window_width/2 - volumeW/2)
-    local volumeY = blackImage:getHeight()*blackImageScale - 260
+    local volumeW = (dimensions.window_width * 1 / 3.75)
+    local volumeX = (dimensions.window_width / 2 - volumeW / 2)
+    local volumeY = blackImage:getHeight() * blackImageScale - 260
     local volumeH = 60
 
-    local displaymodeW = (dimensions.window_width * 1/3.75 + love.graphics.newText(GameFont, optionsSelections[2]):getWidth())
-    local displaymodeX = (dimensions.window_width/2 - displaymodeW/2)
-    local displaymodeY = blackImage:getHeight()*blackImageScale - 370
+    local displaymodeW =
+        (dimensions.window_width * 1 / 3.75 + love.graphics.newText(GameFont, optionsSelections[2]):getWidth())
+    local displaymodeX = (dimensions.window_width / 2 - displaymodeW / 2)
+    local displaymodeY = blackImage:getHeight() * blackImageScale - 370
     local displaymodeH = 60
 
     local dx = 8
     local dy = 8
 
-    love.graphics.setColor(0.44,0.56,0.89)
+    love.graphics.setColor(0.44, 0.56, 0.89)
     if TitleSelection == "Volume" then
-        love.graphics.rectangle("fill", volumeX-dx, volumeY-dy, volumeW+2*dx, volumeH+2*dy)
+        love.graphics.rectangle("fill", volumeX - dx, volumeY - dy, volumeW + 2 * dx, volumeH + 2 * dy)
     elseif TitleSelection == optionsSelections[2] then
-        love.graphics.rectangle("fill", displaymodeX-dx, displaymodeY-dy, displaymodeW+2*dx, displaymodeH+2*dy)
+        love.graphics.rectangle(
+            "fill",
+            displaymodeX - dx,
+            displaymodeY - dy,
+            displaymodeW + 2 * dx,
+            displaymodeH + 2 * dy
+        )
     else
-        love.graphics.rectangle("fill", backX-dx, backY-dy, backW+2*dx, backH+2*dy)
+        love.graphics.rectangle("fill", backX - dx, backY - dy, backW + 2 * dx, backH + 2 * dy)
     end
 
     love.graphics.setColor(222, 0, 0)
     love.graphics.rectangle("fill", backX, backY, backW, backH)
 
-    love.graphics.setColor(0.3,0.3,0.3)
+    love.graphics.setColor(0.3, 0.3, 0.3)
     love.graphics.rectangle("fill", volumeX, volumeY, volumeW, volumeH)
 
-    love.graphics.setColor(0.3,0.3,0.3)
+    love.graphics.setColor(0.3, 0.3, 0.3)
     love.graphics.rectangle("fill", displaymodeX, displaymodeY, displaymodeW, displaymodeH)
 
-    love.graphics.setColor(1,1,1)
+    love.graphics.setColor(1, 1, 1)
     local textScale = 3
     local backText = love.graphics.newText(GameFont, "Back")
     love.graphics.draw(
         backText,
-        backX + backW/2-(backText:getWidth() * textScale)/2,
-        backY + backH/2-(backText:getHeight() * textScale)/2,
+        backX + backW / 2 - (backText:getWidth() * textScale) / 2,
+        backY + backH / 2 - (backText:getHeight() * textScale) / 2,
         0,
         textScale,
         textScale
@@ -67,8 +72,8 @@ function DrawOptionsScreen()
     local volumeText = love.graphics.newText(GameFont, "Volume Settings")
     love.graphics.draw(
         volumeText,
-        volumeX + volumeW/2-(volumeText:getWidth() * textScale)/2,
-        volumeY + volumeH/2-(volumeText:getHeight() * textScale)/2,
+        volumeX + volumeW / 2 - (volumeText:getWidth() * textScale) / 2,
+        volumeY + volumeH / 2 - (volumeText:getHeight() * textScale) / 2,
         0,
         textScale,
         textScale
@@ -77,8 +82,8 @@ function DrawOptionsScreen()
     local displaymodeText = love.graphics.newText(GameFont, optionsSelections[2])
     love.graphics.draw(
         displaymodeText,
-        displaymodeX + displaymodeW/2-(displaymodeText:getWidth() * textScale)/2,
-        displaymodeY + displaymodeH/2-(displaymodeText:getHeight() * textScale)/2,
+        displaymodeX + displaymodeW / 2 - (displaymodeText:getWidth() * textScale) / 2,
+        displaymodeY + displaymodeH / 2 - (displaymodeText:getHeight() * textScale) / 2,
         0,
         textScale,
         textScale
@@ -87,8 +92,8 @@ function DrawOptionsScreen()
     return self
 end
 
-TitleSelection = "Back";
-SelectionIndex = 0;
+TitleSelection = "Back"
+SelectionIndex = 0
 blip2 = love.audio.newSource("sounds/selectblip2.wav", "static")
 jingle = love.audio.newSource("sounds/selectjingle.wav", "static")
 blip2:setVolume(settings.sfx_volume / 100 / 2)
@@ -100,59 +105,59 @@ musicFiles = love.filesystem.getDirectoryItems(settings.music_directory)
 soundFiles = love.filesystem.getDirectoryItems(settings.sfx_directory)
 
 for b, i in ipairs(musicFiles) do
-    if string.match(i,".mp3") then
-        local a = i:gsub(".mp3",""):upper()
-        Music[a] = love.audio.newSource(settings.music_directory..i, "static")
-    elseif string.match(i,".wav") then
-        local a = i:gsub(".wav",""):upper()
-        Music[a] = love.audio.newSource(settings.music_directory..i, "static")
+    if string.match(i, ".mp3") then
+        local a = i:gsub(".mp3", ""):upper()
+        Music[a] = love.audio.newSource(settings.music_directory .. i, "static")
+    elseif string.match(i, ".wav") then
+        local a = i:gsub(".wav", ""):upper()
+        Music[a] = love.audio.newSource(settings.music_directory .. i, "static")
     end
 end
 for b, i in ipairs(soundFiles) do
-    if string.match(i,".mp3") then
-        local a = i:gsub(".mp3",""):upper()
-        Sounds[a] = love.audio.newSource(settings.sfx_directory..i, "static")
-    elseif string.match(i,".wav") then
-        local a = i:gsub(".wav",""):upper()
-        Sounds[a] = love.audio.newSource(settings.sfx_directory..i, "static")
+    if string.match(i, ".mp3") then
+        local a = i:gsub(".mp3", ""):upper()
+        Sounds[a] = love.audio.newSource(settings.sfx_directory .. i, "static")
+    elseif string.match(i, ".wav") then
+        local a = i:gsub(".wav", ""):upper()
+        Sounds[a] = love.audio.newSource(settings.sfx_directory .. i, "static")
     end
 end
 
 OptionsConfig = {
-    displayed = false;
+    displayed = false,
     onKeyPressed = function(key)
         if key == controls.start_button then
-            love.graphics.clear(0, 0, 0);
+            love.graphics.clear(0, 0, 0)
             if TitleSelection == "Back" then
                 blip2:stop()
                 blip2:play()
                 if Episode.started then
-                    screens.options.displayed = false;
+                    screens.options.displayed = false
                 else
-                    screens.title.displayed = true;
+                    screens.title.displayed = true
                     DrawTitleScreen()
-                    screens.options.displayed = false;
-                    SelectionIndex = 2;
+                    screens.options.displayed = false
+                    SelectionIndex = 2
                     TitleSelection = "Settings"
                 end
             elseif TitleSelection == "Volume" then
                 blip2:stop()
                 blip2:play()
-                screens.volume.displayed = true;
-                DrawVolumeScreen();
-                screens.options.displayed = false;
-                SelectionIndex = 0;
+                screens.volume.displayed = true
+                DrawVolumeScreen()
+                screens.options.displayed = false
+                SelectionIndex = 0
             elseif TitleSelection == optionsSelections[2] then
                 blip2:stop()
                 blip2:play()
                 if optionsSelections[2] == "Fullscreen" then
                     settings.displayModesIndex = settings.displayModesIndex + 1
-                    love.window.setFullscreen(true);
-                    optionsSelections[2] = "Windowed-Fullscreen";
+                    love.window.setFullscreen(true)
+                    optionsSelections[2] = "Windowed-Fullscreen"
                 elseif optionsSelections[2] == "Windowed-Fullscreen" then
-                    settings.displayModesIndex = settings.displayModesIndex - 1;
-                    love.window.setFullscreen(true, "desktop");
-                    optionsSelections[2] = "Fullscreen";
+                    settings.displayModesIndex = settings.displayModesIndex - 1
+                    love.window.setFullscreen(true, "desktop")
+                    optionsSelections[2] = "Fullscreen"
                 end
                 TitleSelection = optionsSelections[2]
             end
@@ -169,27 +174,27 @@ OptionsConfig = {
             blip2:play()
             SelectionIndex = SelectionIndex - 1
             if (SelectionIndex < 0) then
-                SelectionIndex = 2;
+                SelectionIndex = 2
             end
             TitleSelection = optionsSelections[SelectionIndex]
         end
-    end;
+    end,
     onKeyReleased = function(key)
-    end;
+    end,
     onDisplay = function()
         screens.pause.displayed = false
         screens.courtRecords.displayed = false
         screens.options.displayed = true
         screens.title.displayed = false
         screens.volume.displayed = false
-        TitleSelection = "Back";
-        SelectionIndex = 0;
-    end;
+        TitleSelection = "Back"
+        SelectionIndex = 0
+    end,
     draw = function()
         if screens.options.displayed == true then
             DrawOptionsScreen()
             blip2:setVolume(settings.sfx_volume / 100 / 2)
             jingle:setVolume(settings.sfx_volume / 100 / 2)
         end
-    end;
+    end
 }

--- a/code/screens/volume.lua
+++ b/code/screens/volume.lua
@@ -1,5 +1,4 @@
 function DrawVolumeScreen()
-
     love.graphics.clear(unpack(colors.black))
     GameFont:setLineHeight(1)
 
@@ -7,97 +6,127 @@ function DrawVolumeScreen()
     love.graphics.rectangle("fill", 0, 0, love.graphics.getWidth(), love.graphics.getHeight())
 
     local blackImage = love.graphics.newImage(settings.black_screen_path)
-    local blackImageScale = 2*dimensions.window_width/1920 * 2
+    local blackImageScale = 2 * dimensions.window_width / 1920 * 2
 
-    local backW = (dimensions.window_width * 1/5)
-    local backX = (dimensions.window_width/2 - backW/2)
-    local backY = blackImage:getHeight()*blackImageScale + 10
+    local backW = (dimensions.window_width * 1 / 5)
+    local backX = (dimensions.window_width / 2 - backW / 2)
+    local backY = blackImage:getHeight() * blackImageScale + 10
     local backH = 60
 
-    local musicVolumeW = (dimensions.window_width * 1/3.75 + (love.graphics.newText(GameFont, "Music Volume ("..settings.music_volume..")"):getWidth() / 4))
-    local musicVolumeX = (dimensions.window_width/2 - musicVolumeW/2)
-    local musicVolumeY = blackImage:getHeight()*blackImageScale - 480
+    local musicVolumeW =
+        (dimensions.window_width * 1 / 3.75 +
+        (love.graphics.newText(GameFont, "Music Volume (" .. settings.music_volume .. ")"):getWidth() / 4))
+    local musicVolumeX = (dimensions.window_width / 2 - musicVolumeW / 2)
+    local musicVolumeY = blackImage:getHeight() * blackImageScale - 480
     local musicVolumeH = 60
 
-    local sfxVolumeW = (dimensions.window_width * 1/3.75 + (love.graphics.newText(GameFont, "SFX Volume ("..settings.sfx_volume..")"):getWidth() / 4))
-    local sfxVolumeX = (dimensions.window_width/2 - sfxVolumeW/2)
-    local sfxVolumeY = blackImage:getHeight()*blackImageScale - 370
+    local sfxVolumeW =
+        (dimensions.window_width * 1 / 3.75 +
+        (love.graphics.newText(GameFont, "SFX Volume (" .. settings.sfx_volume .. ")"):getWidth() / 4))
+    local sfxVolumeX = (dimensions.window_width / 2 - sfxVolumeW / 2)
+    local sfxVolumeY = blackImage:getHeight() * blackImageScale - 370
     local sfxVolumeH = 60
 
-    local speechVolumeW = (dimensions.window_width * 1/3.75 + (love.graphics.newText(GameFont, "Speech Volume ("..settings.speech_volume..")"):getWidth() / 4))
-    local speechVolumeX = (dimensions.window_width/2 - speechVolumeW/2)
-    local speechVolumeY = blackImage:getHeight()*blackImageScale - 260
+    local speechVolumeW =
+        (dimensions.window_width * 1 / 3.75 +
+        (love.graphics.newText(GameFont, "Speech Volume (" .. settings.speech_volume .. ")"):getWidth() / 4))
+    local speechVolumeX = (dimensions.window_width / 2 - speechVolumeW / 2)
+    local speechVolumeY = blackImage:getHeight() * blackImageScale - 260
     local speechVolumeH = 60
 
     local dx = 8
     local dy = 8
 
-    love.graphics.setColor(0.44,0.56,0.89)
+    love.graphics.setColor(0.44, 0.56, 0.89)
     if TitleSelection == "SFX Volume" then
-        love.graphics.rectangle("fill", sfxVolumeX-dx, sfxVolumeY-dy, sfxVolumeW+2*dx, sfxVolumeH+2*dy)
+        love.graphics.rectangle("fill", sfxVolumeX - dx, sfxVolumeY - dy, sfxVolumeW + 2 * dx, sfxVolumeH + 2 * dy)
     elseif TitleSelection == "Speech Volume" then
-        love.graphics.rectangle("fill", speechVolumeX-dx, speechVolumeY-dy, speechVolumeW+2*dx, speechVolumeH+2*dy)
+        love.graphics.rectangle(
+            "fill",
+            speechVolumeX - dx,
+            speechVolumeY - dy,
+            speechVolumeW + 2 * dx,
+            speechVolumeH + 2 * dy
+        )
     elseif TitleSelection == "Music Volume" then
-        love.graphics.rectangle("fill", musicVolumeX-dx, musicVolumeY-dy, musicVolumeW+2*dx, musicVolumeH+2*dy)
+        love.graphics.rectangle(
+            "fill",
+            musicVolumeX - dx,
+            musicVolumeY - dy,
+            musicVolumeW + 2 * dx,
+            musicVolumeH + 2 * dy
+        )
     else
-        love.graphics.rectangle("fill", backX-dx, backY-dy, backW+2*dx, backH+2*dy)
+        love.graphics.rectangle("fill", backX - dx, backY - dy, backW + 2 * dx, backH + 2 * dy)
     end
 
     love.graphics.setColor(222, 0, 0)
     love.graphics.rectangle("fill", backX, backY, backW, backH)
 
-    love.graphics.setColor(0.3,0.3,0.3)
+    love.graphics.setColor(0.3, 0.3, 0.3)
     love.graphics.rectangle("fill", musicVolumeX, musicVolumeY, musicVolumeW, musicVolumeH)
-    love.graphics.setColor(0.25,0.41,0.88)
-    love.graphics.rectangle("fill", musicVolumeX, musicVolumeY, (musicVolumeW / 100) * settings.music_volume, musicVolumeH)
+    love.graphics.setColor(0.25, 0.41, 0.88)
+    love.graphics.rectangle(
+        "fill",
+        musicVolumeX,
+        musicVolumeY,
+        (musicVolumeW / 100) * settings.music_volume,
+        musicVolumeH
+    )
 
-    love.graphics.setColor(0.3,0.3,0.3)
+    love.graphics.setColor(0.3, 0.3, 0.3)
     love.graphics.rectangle("fill", sfxVolumeX, sfxVolumeY, sfxVolumeW, sfxVolumeH)
-    love.graphics.setColor(0.25,0.41,0.88)
+    love.graphics.setColor(0.25, 0.41, 0.88)
     love.graphics.rectangle("fill", sfxVolumeX, sfxVolumeY, (sfxVolumeW / 100) * settings.sfx_volume, sfxVolumeH)
 
-    love.graphics.setColor(0.3,0.3,0.3)
+    love.graphics.setColor(0.3, 0.3, 0.3)
     love.graphics.rectangle("fill", speechVolumeX, speechVolumeY, speechVolumeW, speechVolumeH)
-    love.graphics.setColor(0.25,0.41,0.88)
-    love.graphics.rectangle("fill", speechVolumeX, speechVolumeY, (speechVolumeW / 100) * settings.speech_volume, speechVolumeH)
+    love.graphics.setColor(0.25, 0.41, 0.88)
+    love.graphics.rectangle(
+        "fill",
+        speechVolumeX,
+        speechVolumeY,
+        (speechVolumeW / 100) * settings.speech_volume,
+        speechVolumeH
+    )
 
-    love.graphics.setColor(1,1,1)
+    love.graphics.setColor(1, 1, 1)
     local textScale = 3
     local backText = love.graphics.newText(GameFont, "Back")
     love.graphics.draw(
         backText,
-        backX + backW/2-(backText:getWidth() * textScale)/2,
-        backY + backH/2-(backText:getHeight() * textScale)/2,
+        backX + backW / 2 - (backText:getWidth() * textScale) / 2,
+        backY + backH / 2 - (backText:getHeight() * textScale) / 2,
         0,
         textScale,
         textScale
     )
 
-    local musicVolumeText = love.graphics.newText(GameFont, "Music Volume ("..settings.music_volume..")")
+    local musicVolumeText = love.graphics.newText(GameFont, "Music Volume (" .. settings.music_volume .. ")")
     love.graphics.draw(
         musicVolumeText,
-        musicVolumeX + musicVolumeW/2-(musicVolumeText:getWidth() * textScale)/2,
-        musicVolumeY + musicVolumeH/2-(musicVolumeText:getHeight() * textScale)/2,
+        musicVolumeX + musicVolumeW / 2 - (musicVolumeText:getWidth() * textScale) / 2,
+        musicVolumeY + musicVolumeH / 2 - (musicVolumeText:getHeight() * textScale) / 2,
         0,
         textScale,
         textScale
     )
 
-    local sfxVolumeText = love.graphics.newText(GameFont, "SFX Volume ("..settings.sfx_volume..")")
+    local sfxVolumeText = love.graphics.newText(GameFont, "SFX Volume (" .. settings.sfx_volume .. ")")
     love.graphics.draw(
         sfxVolumeText,
-        sfxVolumeX + sfxVolumeW/2-(sfxVolumeText:getWidth() * textScale)/2,
-        sfxVolumeY + sfxVolumeH/2-(sfxVolumeText:getHeight() * textScale)/2,
+        sfxVolumeX + sfxVolumeW / 2 - (sfxVolumeText:getWidth() * textScale) / 2,
+        sfxVolumeY + sfxVolumeH / 2 - (sfxVolumeText:getHeight() * textScale) / 2,
         0,
         textScale,
         textScale
     )
 
-    local speechVolumeText = love.graphics.newText(GameFont, "Speech Volume ("..settings.speech_volume..")")
+    local speechVolumeText = love.graphics.newText(GameFont, "Speech Volume (" .. settings.speech_volume .. ")")
     love.graphics.draw(
         speechVolumeText,
-        speechVolumeX + speechVolumeW/2-(speechVolumeText:getWidth() * textScale)/2,
-        speechVolumeY + speechVolumeH/2-(speechVolumeText:getHeight() * textScale)/2,
+        speechVolumeX + speechVolumeW / 2 - (speechVolumeText:getWidth() * textScale) / 2,
+        speechVolumeY + speechVolumeH / 2 - (speechVolumeText:getHeight() * textScale) / 2,
         0,
         textScale,
         textScale
@@ -107,12 +136,12 @@ function DrawVolumeScreen()
 end
 
 volumeSelections = {}
-volumeSelections[0] = "Back";
-volumeSelections[1] = "Speech Volume";
-volumeSelections[2] = "SFX Volume";
-volumeSelections[3] = "Music Volume";
-TitleSelection = "Back";
-SelectionIndex = 0;
+volumeSelections[0] = "Back"
+volumeSelections[1] = "Speech Volume"
+volumeSelections[2] = "SFX Volume"
+volumeSelections[3] = "Music Volume"
+TitleSelection = "Back"
+SelectionIndex = 0
 blip2 = love.audio.newSource("sounds/selectblip2.wav", "static")
 jingle = love.audio.newSource("sounds/selectjingle.wav", "static")
 blip2:setVolume(settings.sfx_volume / 100 / 2)
@@ -124,42 +153,42 @@ musicFiles = love.filesystem.getDirectoryItems(settings.music_directory)
 soundFiles = love.filesystem.getDirectoryItems(settings.sfx_directory)
 
 for b, i in ipairs(musicFiles) do
-    if string.match(i,".mp3") then
-        local a = i:gsub(".mp3",""):upper()
-        Music[a] = love.audio.newSource(settings.music_directory..i, "static")
-    elseif string.match(i,".wav") then
-        local a = i:gsub(".wav",""):upper()
-        Music[a] = love.audio.newSource(settings.music_directory..i, "static")
+    if string.match(i, ".mp3") then
+        local a = i:gsub(".mp3", ""):upper()
+        Music[a] = love.audio.newSource(settings.music_directory .. i, "static")
+    elseif string.match(i, ".wav") then
+        local a = i:gsub(".wav", ""):upper()
+        Music[a] = love.audio.newSource(settings.music_directory .. i, "static")
     end
 end
 for b, i in ipairs(soundFiles) do
-    if string.match(i,".mp3") then
-        local a = i:gsub(".mp3",""):upper()
-        Sounds[a] = love.audio.newSource(settings.sfx_directory..i, "static")
-    elseif string.match(i,".wav") then
-        local a = i:gsub(".wav",""):upper()
-        Sounds[a] = love.audio.newSource(settings.sfx_directory..i, "static")
+    if string.match(i, ".mp3") then
+        local a = i:gsub(".mp3", ""):upper()
+        Sounds[a] = love.audio.newSource(settings.sfx_directory .. i, "static")
+    elseif string.match(i, ".wav") then
+        local a = i:gsub(".wav", ""):upper()
+        Sounds[a] = love.audio.newSource(settings.sfx_directory .. i, "static")
     end
 end
 
 VolumeConfig = {
-    displayed = false;
+    displayed = false,
     onKeyPressed = function(key)
         if key == controls.start_button then
-            love.graphics.clear(0, 0, 0);
+            love.graphics.clear(0, 0, 0)
             if TitleSelection == "Back" then
                 blip2:stop()
-                blip2:play();
-                screens.options.displayed = true;
-                DrawOptionsScreen();
-                screens.volume.displayed = false;
-                SelectionIndex = 1;
-                TitleSelection = "Volume";
+                blip2:play()
+                screens.options.displayed = true
+                DrawOptionsScreen()
+                screens.volume.displayed = false
+                SelectionIndex = 1
+                TitleSelection = "Volume"
             end
         elseif key == controls.pause_nav_up then
             blip2:stop()
             blip2:play()
-            SelectionIndex = SelectionIndex + 1;
+            SelectionIndex = SelectionIndex + 1
             if (SelectionIndex > 3) then
                 SelectionIndex = 0
             end
@@ -167,91 +196,91 @@ VolumeConfig = {
         elseif key == controls.pause_nav_down then
             blip2:stop()
             blip2:play()
-            SelectionIndex = SelectionIndex - 1;
+            SelectionIndex = SelectionIndex - 1
             if (SelectionIndex < 0) then
-                SelectionIndex = 3;
+                SelectionIndex = 3
             end
             TitleSelection = volumeSelections[SelectionIndex]
         elseif key == controls.press_right then
             if TitleSelection == "Music Volume" then
                 if settings.music_volume < 100 then
-                    settings.music_volume = settings.music_volume + 5;
-                    MusicVolume = settings.music_volume;
-                    for i,v in pairs(Music) do
-                        v:setVolume(settings.music_volume / 100);
+                    settings.music_volume = settings.music_volume + 5
+                    MusicVolume = settings.music_volume
+                    for i, v in pairs(Music) do
+                        v:setVolume(settings.music_volume / 100)
                     end
-                    blip2:stop();
-                    blip2:play();
+                    blip2:stop()
+                    blip2:play()
                 end
             elseif TitleSelection == "SFX Volume" then
                 if settings.sfx_volume < 100 then
-                    settings.sfx_volume = settings.sfx_volume + 5;
+                    settings.sfx_volume = settings.sfx_volume + 5
                     SFXVolume = settings.sfx_volume
-                    for i,v in pairs(Sounds) do
+                    for i, v in pairs(Sounds) do
                         if i ~= "maletalk" and i ~= "femaletalk" then
-                            v:setVolume(settings.sfx_volume / 100);
+                            v:setVolume(settings.sfx_volume / 100)
                         end
                     end
-                    blip2:stop();
-                    blip2:play();
+                    blip2:stop()
+                    blip2:play()
                 end
             elseif TitleSelection == "Speech Volume" then
                 if settings.speech_volume < 100 then
-                    settings.speech_volume = settings.speech_volume + 5;
-                    SFXVolume = settings.speech_volume;
-                    blip2:stop();
-                    blip2:play();
+                    settings.speech_volume = settings.speech_volume + 5
+                    SFXVolume = settings.speech_volume
+                    blip2:stop()
+                    blip2:play()
                 end
             end
         elseif key == controls.press_left then
             if TitleSelection == "Music Volume" then
                 if settings.music_volume > 0 then
-                    settings.music_volume = settings.music_volume - 5;
-                    MusicVolume = settings.music_volume;
-                    for i,v in pairs(Music) do
-                        v:setVolume(settings.music_volume / 100);
+                    settings.music_volume = settings.music_volume - 5
+                    MusicVolume = settings.music_volume
+                    for i, v in pairs(Music) do
+                        v:setVolume(settings.music_volume / 100)
                     end
-                    blip2:stop();
-                    blip2:play();
+                    blip2:stop()
+                    blip2:play()
                 end
             elseif TitleSelection == "SFX Volume" then
                 if settings.sfx_volume > 0 then
-                    settings.sfx_volume = settings.sfx_volume - 5;
-                    SFXVolume = settings.sfx_volume;
-                    for i,v in pairs(Sounds) do
+                    settings.sfx_volume = settings.sfx_volume - 5
+                    SFXVolume = settings.sfx_volume
+                    for i, v in pairs(Sounds) do
                         if i ~= "maletalk" and i ~= "femaletalk" then
-                            v:setVolume(settings.sfx_volume / 100);
+                            v:setVolume(settings.sfx_volume / 100)
                         end
                     end
-                    blip2:stop();
-                    blip2:play();
+                    blip2:stop()
+                    blip2:play()
                 end
             elseif TitleSelection == "Speech Volume" then
                 if settings.speech_volume > 0 then
-                    settings.speech_volume = settings.speech_volume - 5;
-                    SFXVolume = settings.speech_volume;
-                    blip2:stop();
-                    blip2:play();
+                    settings.speech_volume = settings.speech_volume - 5
+                    SFXVolume = settings.speech_volume
+                    blip2:stop()
+                    blip2:play()
                 end
             end
         end
-    end;
+    end,
     onKeyReleased = function(key)
-    end;
+    end,
     onDisplay = function()
         screens.pause.displayed = false
         screens.courtRecords.displayed = false
         screens.options.displayed = false
         screens.title.displayed = false
         screens.volume.displayed = true
-        TitleSelection = "Back";
-        SelectionIndex = 0;
-    end;
+        TitleSelection = "Back"
+        SelectionIndex = 0
+    end,
     draw = function()
         if screens.volume.displayed == true then
             DrawVolumeScreen()
             blip2:setVolume(settings.sfx_volume / 100 / 2)
             jingle:setVolume(settings.sfx_volume / 100 / 2)
         end
-    end;
+    end
 }

--- a/code/screens/volume.lua
+++ b/code/screens/volume.lua
@@ -146,30 +146,6 @@ blip2 = love.audio.newSource("sounds/selectblip2.wav", "static")
 jingle = love.audio.newSource("sounds/selectjingle.wav", "static")
 blip2:setVolume(settings.sfx_volume / 100 / 2)
 jingle:setVolume(settings.sfx_volume / 100 / 2)
-Music = {}
-Sounds = {}
-
-musicFiles = love.filesystem.getDirectoryItems(settings.music_directory)
-soundFiles = love.filesystem.getDirectoryItems(settings.sfx_directory)
-
-for b, i in ipairs(musicFiles) do
-    if string.match(i, ".mp3") then
-        local a = i:gsub(".mp3", ""):upper()
-        Music[a] = love.audio.newSource(settings.music_directory .. i, "static")
-    elseif string.match(i, ".wav") then
-        local a = i:gsub(".wav", ""):upper()
-        Music[a] = love.audio.newSource(settings.music_directory .. i, "static")
-    end
-end
-for b, i in ipairs(soundFiles) do
-    if string.match(i, ".mp3") then
-        local a = i:gsub(".mp3", ""):upper()
-        Sounds[a] = love.audio.newSource(settings.sfx_directory .. i, "static")
-    elseif string.match(i, ".wav") then
-        local a = i:gsub(".wav", ""):upper()
-        Sounds[a] = love.audio.newSource(settings.sfx_directory .. i, "static")
-    end
-end
 
 VolumeConfig = {
     displayed = false,

--- a/main.lua
+++ b/main.lua
@@ -10,7 +10,7 @@ require "code/scriptloader"
 local logoOpacity = 1
 local drawLogo = true
 local logoTimer = 0
-local doneLoading = false
+local isDoneLoading = false
 local AssetLoader
 local currentLoadingAsset
 
@@ -43,7 +43,7 @@ end
 -- transfer the update and draw over to the current game scene
 function love.update(dt)
     -- Loading Screen
-    if not doneLoading then
+    if not isDoneLoading then
         currentLoadingAsset = AssetLoader.lambdas[AssetLoader.index]
         if currentLoadingAsset then
             currentLoadingAsset()
@@ -51,7 +51,7 @@ function love.update(dt)
             return -- skip the rest of this update, we're still in the loading screen
         end
 
-        doneLoading = true
+        isDoneLoading = true
     end
     -- /Loading Screen
 
@@ -127,6 +127,13 @@ function love.draw()
             0.35,
             0.35
         )
+
+        if not isDoneLoading then
+            love.graphics.setFont(LoadingFont)
+            local percent = math.floor((AssetLoader.index - 1) / #AssetLoader.lambdas * 100)
+            local lx, ly = math.floor(dimensions.window_height * 0.8), math.floor(dimensions.window_width)
+            love.graphics.printf("Loading: " .. percent .. "%", 0, lx, ly, "center")
+        end
     else
         love.graphics.setColor(unpack(colors.white))
         love.graphics.setCanvas(Renderable)

--- a/main.lua
+++ b/main.lua
@@ -11,7 +11,6 @@ local logoOpacity = 1
 local drawLogo = true
 local logoTimer = 0
 
-
 function love.load()
     InitGlobalConfigVariables()
     love.window.setFullscreen(true, "desktop")
@@ -24,7 +23,7 @@ function love.load()
     ScreenShake = 0
     DtReset = false -- so scene load times don't factor into dt
 
-    LoadAssets()
+    loadingLambdas = LoadAssets()
     Episode = NewEpisode(settings.episode_path)
 
     -- Select the first scene in the loaded episode
@@ -41,7 +40,7 @@ end
 -- transfer the update and draw over to the current game scene
 function love.update(dt)
     if DtReset then
-        dt = 1/60
+        dt = 1 / 60
         DtReset = false
     end
 
@@ -63,7 +62,7 @@ end
 
 function love.keypressed(key)
     if drawLogo then
-        return;
+        return
     end
     local currentDisplayedScreen
     local nextScreenToDisplay
@@ -75,8 +74,10 @@ function love.keypressed(key)
             currentDisplayedScreen = screenName
         end
 
-        if screenConfig.displayKey and key == screenConfig.displayKey and
-            (screenConfig.displayCondition == nil or screenConfig.displayCondition()) then
+        if
+            screenConfig.displayKey and key == screenConfig.displayKey and
+                (screenConfig.displayCondition == nil or screenConfig.displayCondition())
+         then
             if screenName == currentDisplayedScreen then
                 screenConfig.displayed = false
             else
@@ -85,7 +86,6 @@ function love.keypressed(key)
         elseif screenConfig.displayed and screenConfig.onKeyPressed then
             screenConfig.onKeyPressed(key)
         end
-
     end
 
     if nextScreenToDisplay and currentDisplayedScreen == nil then
@@ -99,12 +99,18 @@ end
 logo = love.graphics.newImage("studioloveliesfinal.png")
 
 function love.draw()
-
     if drawLogo then
         love.graphics.setColor(0, 0, 0)
         love.graphics.rectangle("fill", 0, 0, dimensions.window_width, dimensions.window_height)
         love.graphics.setColor(1, 1, 1, logoOpacity)
-        love.graphics.draw(logo, dimensions.window_width/2 - logo:getWidth()/5.71, dimensions.window_height/2 - logo:getHeight()/5.71, 0, 0.35, 0.35)
+        love.graphics.draw(
+            logo,
+            dimensions.window_width / 2 - logo:getWidth() / 5.71,
+            dimensions.window_height / 2 - logo:getHeight() / 5.71,
+            0,
+            0.35,
+            0.35
+        )
     else
         love.graphics.setColor(unpack(colors.white))
         love.graphics.setCanvas(Renderable)
@@ -112,10 +118,10 @@ function love.draw()
         CurrentScene:draw()
         love.graphics.setCanvas()
 
-        local dx,dy = 0,0
+        local dx, dy = 0, 0
         if ScreenShake > 0 then
-            dx = love.math.random() * choose{1, -1} * 2
-            dy = love.math.random() * choose{1, -1} * 2
+            dx = love.math.random() * choose {1, -1} * 2
+            dy = love.math.random() * choose {1, -1} * 2
         end
 
         --dx = camerapan[1]
@@ -125,11 +131,11 @@ function love.draw()
 
         love.graphics.draw(
             Renderable,
-            dx*love.graphics.getWidth()/GraphicsWidth,
-            dy*love.graphics.getHeight()/GraphicsHeight,
+            dx * love.graphics.getWidth() / GraphicsWidth,
+            dy * love.graphics.getHeight() / GraphicsHeight,
             0,
-            love.graphics.getWidth()/GraphicsWidth,
-            love.graphics.getHeight()/GraphicsHeight
+            love.graphics.getWidth() / GraphicsWidth,
+            love.graphics.getHeight() / GraphicsHeight
         )
 
         for screenName, screenConfig in pairs(screens) do

--- a/main.lua
+++ b/main.lua
@@ -27,6 +27,9 @@ function love.load()
     DtReset = false -- so scene load times don't factor into dt
 
     AssetLoader = {lambdas = LoadAssets(), index = 1}
+end
+
+function OnLoadingScreenDone()
     Episode = NewEpisode(settings.episode_path)
 
     -- Select the first scene in the loaded episode
@@ -52,6 +55,7 @@ function love.update(dt)
         end
 
         FinishLoadingAssets()
+        OnLoadingScreenDone()
         isDoneLoading = true
     end
     -- /Loading Screen

--- a/main.lua
+++ b/main.lua
@@ -51,6 +51,7 @@ function love.update(dt)
             return -- skip the rest of this update, we're still in the loading screen
         end
 
+        FinishLoadingAssets()
         isDoneLoading = true
     end
     -- /Loading Screen

--- a/main.lua
+++ b/main.lua
@@ -48,10 +48,23 @@ function love.update(dt)
     -- Loading Screen
     if not isDoneLoading then
         currentLoadingAsset = AssetLoader.lambdas[AssetLoader.index]
-        if currentLoadingAsset then
+        local timeAtStartOfFrame = love.timer.getTime()
+
+        local loadingDt = 0
+
+        while currentLoadingAsset and loadingDt < 1 / 60 do
+            -- loads an asset and tracks how long we've spent loading that asset
+            -- if we took less than 1/60 seconds to load, then load the next asset
             currentLoadingAsset()
+
             AssetLoader.index = AssetLoader.index + 1
-            return -- skip the rest of this update, we're still in the loading screen
+            currentLoadingAsset = AssetLoader.lambdas[AssetLoader.index]
+            loadingDt = love.timer.getTime() - timeAtStartOfFrame
+        end
+
+        if currentLoadingAsset then
+            -- we still have more loading to do; skip the rest of update()
+            return
         end
 
         FinishLoadingAssets()

--- a/main.lua
+++ b/main.lua
@@ -10,6 +10,8 @@ require "code/scriptloader"
 local logoOpacity = 1
 local drawLogo = true
 local logoTimer = 0
+local AssetLoader
+local currentLoadingAsset
 
 function love.load()
     InitGlobalConfigVariables()
@@ -23,7 +25,7 @@ function love.load()
     ScreenShake = 0
     DtReset = false -- so scene load times don't factor into dt
 
-    loadingLambdas = LoadAssets()
+    AssetLoader = {lambdas = LoadAssets(), index = 1}
     Episode = NewEpisode(settings.episode_path)
 
     -- Select the first scene in the loaded episode
@@ -39,6 +41,15 @@ end
 -- love.update and love.draw get called 60 times per second
 -- transfer the update and draw over to the current game scene
 function love.update(dt)
+    -- Loading Screen
+    currentLoadingAsset = AssetLoader.lambdas[AssetLoader.index]
+    if currentLoadingAsset then
+        currentLoadingAsset()
+        AssetLoader.index = AssetLoader.index + 1
+        return -- skip the rest of this update, we're still in the loading screen
+    end
+    -- /Loading Screen
+
     if DtReset then
         dt = 1 / 60
         DtReset = false

--- a/main.lua
+++ b/main.lua
@@ -10,6 +10,7 @@ require "code/scriptloader"
 local logoOpacity = 1
 local drawLogo = true
 local logoTimer = 0
+local doneLoading = false
 local AssetLoader
 local currentLoadingAsset
 
@@ -42,11 +43,15 @@ end
 -- transfer the update and draw over to the current game scene
 function love.update(dt)
     -- Loading Screen
-    currentLoadingAsset = AssetLoader.lambdas[AssetLoader.index]
-    if currentLoadingAsset then
-        currentLoadingAsset()
-        AssetLoader.index = AssetLoader.index + 1
-        return -- skip the rest of this update, we're still in the loading screen
+    if not doneLoading then
+        currentLoadingAsset = AssetLoader.lambdas[AssetLoader.index]
+        if currentLoadingAsset then
+            currentLoadingAsset()
+            AssetLoader.index = AssetLoader.index + 1
+            return -- skip the rest of this update, we're still in the loading screen
+        end
+
+        doneLoading = true
     end
     -- /Loading Screen
 


### PR DESCRIPTION
Good morning! I noticed when I tried to load the game it hiccups pretty bad on launch and I had a hypothesis as to why. The PR is the result of my investigation.

## The Problem (Player's Perspective) ##
When you launch the game, the first thing you see is a blank white window. If the user clicks the window, the OS will think the app is crashed (because it's stuck on the UI thread). The correct thing for the player to do is wait 30(!) seconds for the window to go away and for the game to start in earnest. This makes me sad.

## The Problem (Dev perspective) ##
We're loading a shitload of assets on frame 0. Some of which we're loading redundantly (Sounds and Music are loaded THREE TIMES?!). Disk IO is expensive and doing it all at once really adds up.

## Solution ##
`assets.lua`, `options.lua`, and `volume.lua` all load ALL SFX and ALL Music. From my analysis it looks like volume.lua and options.lua don't need to load them at all. So I removed all but `assets.lua`

I also made `assets.lua` not load all at once, it now loads incrementally on `update()`. You can follow my commits to see how I did this safely but essentially:

* I refactored each function to just be one for loop and nothing else
* Making sure everything is either global on purpose or local to the function, I capture the content of each loop iteration in a lambda
* `LoadAssets` collects up all the lambdas from all the sub-functions into a list
* On `update` we nibble at the list, loading just a few assets each frame
* Bonus: On `draw` we report the progress to the user

This means:
* We never block the UI thread ✨ 
* Although load time is still slow there's a loading bar to indicate that it's thinking

## Metrics ##
- Baseline: it takes 28 seconds for me to get to the title screen, (on a fancy M.2 drive! imagine little Johnny playing the game on his dad's Dell Inspiron!)
- Removing the sound initialization from `options.lua` and `volume.lua` basically fixes the white screen problem and shaves 12 seconds (down to 16)
- My initial loading screen implementation actually slowed us down to 17 second, possibly because we're only loading one asset per frame so if an asset takes less than 1/60 seconds to load we're wasting time
- My second pass on the loading screen allows us to load more than 1 asset per frame, that shaved off about 1 second. (So we're back to 16, BUT we don't block on UI thread at all anymore)

## Formatting ##
I use an aggressive auto-formatter in my IDE. I don't actually have any opinions on formatting aside from "humans should not care about formatting" it's the computer's problem to solve. If you're unhappy with my formatting changes, I can attempt to roll them back and turn off my formatter, but I really prefer using it because I hate pressing tab.

## Testing ##
It's hard to validate changes like this, (which is why I tried to make changes as safely and incrementally as possible). One strategy is just "play the game and see if it's broken" but that's risky because I could easily have missed something.

All is not lost though, I do have a strategy: I put this snippet at the top of `main.lua`

```
local oldfn = love.graphics.newImage
love.graphics.newImage = function(...)
    print("newImage", ...)
    return oldfn(...)
end

local oldfn2 = love.audio.newSource
love.audio.newSource = function(...)
    print("newSource", ...)
    return oldfn2(...)
end
```

This hacks newSource and newImage to print every single time they're called, along with their arguments. I ran both master and my branch with this snippet pasted at the top of main.lua to audit the calls of each. 

In master we call newImage 269 times and newSource 267 times on load. 
In my branch we newImage 269 times and newSource 101 times. However I looked at the outputs of both cases and accounting for duplicates, everyone is accounted for.

Here's another strategy: what if we count the number of entries in each Asset table? (`Backgrounds`, `Sounds`, `Sprites`, etc). I did that with this snippet:

```
    -- Given a table {foo = 3, bar = 7, baz = "Hello world"}
    -- Returns {"foo", "bar", "baz"}
    local function getKeys(table)
        local keyset = {}
        local n = 0
        for k, v in pairs(table) do
            n = n + 1
            keyset[n] = k
        end
        return keyset
    end

print(#getKeys(Backgrounds),"Backgrounds",#getKeys(Music),"Music",#getKeys(Sprites),"Sprites",#getKeys(Shouts),"Shouts",#getKeys(Sounds), "Sounds")
```

I ran the above snippet in both master and my task branch once the assets were done loading. In both cases I got the exact same output: `17 Backgrounds  32 Music  120 Sprites  3 Shouts  51 Sounds`

After load there are a few times we call newImage, and there are a few sources we read off disk multiple times (blip, for example). I decided to ignore those... for now

## Possible Future Work ##
* Now that we have a loading screen, we can put funny memes and/or grumps references in the loading screen text.
* Right now the loading screen just says "Loading" followed by a percent, it could easily be a bar that fills up

## Appendix: ##
All calls to newImage and newSource in master (sorted alphabetically)
https://pastebin.com/Q408fqYb

All calls to newImage and newSource in my branch (sorted alphabetically)
https://pastebin.com/e4naZFyy


I'm happy to chat about this change either in the comments here or on discord. Thanks!